### PR TITLE
Fix to example JSON uses double quotation marks instead on single ones

### DIFF
--- a/sources/reference/tutorials/tolerance.md
+++ b/sources/reference/tutorials/tolerance.md
@@ -348,7 +348,7 @@ For instance, let's assume you receive the following payload:
 
 ```json
 {
-    'foo': [{"baz": "hello"}, {"baz": "bonjour"}]
+    "foo": [{"baz": "hello"}, {"baz": "bonjour"}]
 }
 ```
 


### PR DESCRIPTION
Found this small JSON error while browsing the documentation.

Signed-off-by: Simon Lindroos <simon.h.lindroos@gmail.com>