### PR TITLE
fix vault secret examples

### DIFF
--- a/sources/reference/api/experiment.md
+++ b/sources/reference/api/experiment.md
@@ -690,6 +690,9 @@ path MUST be set to the Chaos Toolkit secret key.
 A `key` property MAY be set to select a specific value from the Vault secret
 payload.
 
+The Vault url MUST be provided in the Configuration section via
+the `"vault_addr"` property.
+
 Vault authentication MUST at least support:
 
 * [token][vaulttoken] based authentication
@@ -807,7 +810,7 @@ can be undefined and fallback to a default value for the experiment.
 ```json
 {
     "configuration": {
-        "vault_address": {
+        "vault_addr": {
             "type": "env",
             "key": "VAULT_ADDR",
             "default": "https://127.0.0.1:8200"

--- a/sources/reference/api/experiment.md
+++ b/sources/reference/api/experiment.md
@@ -696,7 +696,7 @@ Vault authentication MUST at least support:
   The token MUST be provided in the Configuration section via the
   `"vault_token"` property
 * [AppRole][approle] authentication
-  The role-id and secret-id MUST be provided in the Configuration section vi
+  The role-id and secret-id MUST be provided in the Configuration section via
   the `"vault_role_id"` and `"vault_role_secret"` properties
 
 The Vault [KV secrets version][kvversion] MAY be provided via the
@@ -736,7 +736,7 @@ Then in your Chaos Toolkit experiment:
 means the secrets will become:
 
 ```
-"myapp": {
+"token": {
     "foo": "bar",
     "baz": "hello"
 }
@@ -761,7 +761,7 @@ However:
 means the secrets will become:
 
 ```
-"myapp": "bar"
+"token": "bar"
 ```
 
 ### Configuration

--- a/sources/reference/api/experiment.md
+++ b/sources/reference/api/experiment.md
@@ -643,6 +643,16 @@ This can then referenced from probes or actions:
 
 Secrets MAY be inlined in the [Experiment][exp] directly.
 
+```json
+{
+    "secrets": {
+        "kubernetes": {
+            "token": "ABCDEF-1234-XYZ"
+        }
+    }
+}
+```
+
 #### Environment Secrets
 
 Secrets MAY be retrieved from the environment. In that case, they must be
@@ -797,6 +807,14 @@ An example of a `configuration` element at the top-level:
 #### Inline Configurations
 
 Configurations MAY be inlined in the [Experiment][exp] directly.
+
+```json
+{
+    "configuration": {
+        "some-service": "http://127.0.0.1:8080"
+    }
+}
+```
 
 #### Environment Configurations
 


### PR DESCRIPTION
- Fix loaded vault secrets keys in examples (secret group name was used instead of the secret key itself)
- Add missing vault address property missing in configuration (when setting up vault secrets, nothing was clear on how the ctk will talk to the vault server)
- Add json examples for inline secrets & config 
