### PR TITLE
Fix: `version` property `"0.1.0"` to `"1.0.0"` at Experiment

### DIFF
--- a/sources/reference/api/experiment.md
+++ b/sources/reference/api/experiment.md
@@ -89,7 +89,7 @@ An experiment MUST declare:
 * a `description` property
 * a `method` property
 
-The `version` property MUST be `"0.1.0"`.
+The `version` property MUST be `"1.0.0"`.
 
 The experiment's `title` and `description` are meant for humans and therefore
 should be as descriptive as possible to clarify the experiment's rationale.


### PR DESCRIPTION
`Experiment` page shows "The version property MUST be "0.1.0"."

https://docs.chaostoolkit.org/reference/api/experiment/#experiment

However, tutorial page & test code use "1.0.0".

https://docs.chaostoolkit.org/reference/tutorial/

https://github.com/chaostoolkit/chaostoolkit-lib/blob/f781dfea92b3f6fc940a1fa5c7a17d06f5a74bb0/tests/fixtures/experiments.py#L478

We need to version up or delete this line.