### PR TITLE
Add submodules during build to include the tutorial code

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -55,6 +55,7 @@ jobs:
         mkdir /tmp/site
         cd /tmp/site
         git clone https://$GH_USER_NAME:$GH_USER_PWD@github.com/chaostoolkit/chaostoolkit-documentation.git .
+        git submodule update --init
         git checkout gh-pages
         cd -
         mkdocs build --strict -d /tmp/site

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -55,8 +55,8 @@ jobs:
         mkdir /tmp/site
         cd /tmp/site
         git clone https://$GH_USER_NAME:$GH_USER_PWD@github.com/chaostoolkit/chaostoolkit-documentation.git .
-        git submodule update --init
         git checkout gh-pages
         cd -
+        git submodule update --init
         mkdocs build --strict -d /tmp/site
         cd ..

--- a/.github/workflows/build_and_deploy.yaml
+++ b/.github/workflows/build_and_deploy.yaml
@@ -55,9 +55,9 @@ jobs:
         mkdir /tmp/site
         cd /tmp/site
         git clone https://$GH_USER_NAME:$GH_USER_PWD@github.com/chaostoolkit/chaostoolkit-documentation.git .
-        git submodule update --init
         git checkout gh-pages
         cd -
+        git submodule update --init
         mkdocs build --strict -d /tmp/site
         cd ..
     - name: Deploy 🚀

--- a/.github/workflows/build_and_deploy.yaml
+++ b/.github/workflows/build_and_deploy.yaml
@@ -55,6 +55,7 @@ jobs:
         mkdir /tmp/site
         cd /tmp/site
         git clone https://$GH_USER_NAME:$GH_USER_PWD@github.com/chaostoolkit/chaostoolkit-documentation.git .
+        git submodule update --init
         git checkout gh-pages
         cd -
         mkdocs build --strict -d /tmp/site


### PR DESCRIPTION
As per #107, we're not setting up the git submodules in builds, therefore we're not pulling in the walkthrough code

Closes #107

Signed-off-by: Ciaran Evans <ciaran@reliably.com>
