### PR TITLE
Tidy up `init.md`

### DIFF
--- a/sources/reference/usage/init.md
+++ b/sources/reference/usage/init.md
@@ -8,10 +8,20 @@ the target environment.
 You can see the options available to you by executing:
 
 ```
-(chaostk) $ chaos init --help
+chaos init --help
 ```
+```
+Usage: chaos init [OPTIONS]
 
-<div style="margin: 0 auto; text-align: center;"><script src="https://asciinema.org/a/cXD9XCvCXBQEJQsq9MahdRwlE.js" id="asciicast-cXD9XCvCXBQEJQsq9MahdRwlE" async></script></div>
+  Initialize a new experiment from discovered capabilities.
+
+Options:
+  --discovery-path PATH   Path to the discovery outcome.  [default:
+                          ./discovery.json]
+  --experiment-path PATH  Path where to save the experiment (.yaml or .json)
+                          [default: ./experiment.json]
+  --help                  Show this message and exit.
+```
 
 A tutorial on how to use the `chaos init` command is available as part of the 
 [Chaos Toolkit's Getting Started tutorials.](https://www.katacoda.com/chaostoolkit/courses/01-chaostoolkit-getting-started)
@@ -22,8 +32,29 @@ To initialise a new experiment based on what has been [discovered](discover.md)
 you simply need to execute the `chaos init` command:
 
 ```
-(chaostk) $ chaos init
+chaos init
 ```
+
+<div class="screen-reader-text">
+The following is a capture of the output after running chaos init and following the interactive prompts:
+
+[2018-01-30 15:54:50 INFO] Let's build a new experiment
+Experiment's title: My new experiment
+Add an activity to your method
+Activity (0 to escape): 1
+Kill a microservice by `name` in the namespace `ns`.
+
+The microservice is killed by deleting the deployment for it without
+a graceful period to trigger an abrupt termination.
+
+The selected resources are matched by the given `label_selector`.
+Do you want to use this action? [y/N]: y
+Argument's value for 'name':
+Argument's value for 'ns' [default]:
+Argument's value for 'label_selector' [name in ({name})]: app=webapp-app
+Do you want to select another activity? [y/N]: N
+[2018-01-30 15:55:21 INFO] Experiment created and saved in './experiment.json'
+</div>
 
 <div style="margin: 0 auto; text-align: center;"><script src="https://asciinema.org/a/UrLqTuAGyyLoLZrC5c2IAkT50.js" id="asciicast-UrLqTuAGyyLoLZrC5c2IAkT50" async></script></div>
 

--- a/sources/static/css/extra.css
+++ b/sources/static/css/extra.css
@@ -11,3 +11,17 @@
     fill: currentColor;
     object-fit: contain;
 }
+
+/* Text meant only for screen readers. */
+.screen-reader-text {
+    border: 0;
+    clip: rect(1px, 1px, 1px, 1px);
+    clip-path: inset(50%);
+    height: 1px;
+    margin: -1px;
+    overflow: hidden;
+    padding: 0;
+    position: absolute;
+    width: 1px;
+    word-wrap: normal !important;
+  }


### PR DESCRIPTION
This PR tidies up `init.md` by removing prefixes to commands and adding the class `screen-reader-text` from https://make.wordpress.org/accessibility/handbook/markup/the-css-class-screen-reader-text/ so that we can use the asciinema to display the interactive commands but still provide an accessible way to see what happens.

Signed-off-by: Ciaran Evans <ciaran@reliably.com>
