### PR TITLE
Tidy up `notification.md`

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -81,7 +81,7 @@ nav:
         - Init: reference/usage/init.md
         - Run: reference/usage/run.md
         - Report: reference/usage/report.md
-        - Notify: reference/usage/notification.md
+        - Notifications: reference/usage/notification.md
         - Schedule: reference/usage/scheduling.md
 - Guides:
     - Get Started with the Chaos Toolkit: reference/tutorial.md

--- a/sources/reference/usage/notification.md
+++ b/sources/reference/usage/notification.md
@@ -215,8 +215,8 @@ amend it, please open an [issue][slissue] there.
 
 The Chaos Toolkit does its best to not break the experiment when an event
 could not be pushed. If you do not see the notification you were expecting,
-you should start investigating in the `chaostoolkit.log` file. If Chaos Toolkit could handle the issue
-gracefully, it will log the error at the `DEBUG` level.
+you should start investigating in the `chaostoolkit.log` file. If Chaos Toolkit
+could handle the issue gracefully, it will log the error at the `DEBUG` level.
 
 If the error occurs inside the core Chaos Toolkit library, please raise an
 [issue there][chaoslibissues]. Otherwise, raise an issue with the appropriate

--- a/sources/reference/usage/notification.md
+++ b/sources/reference/usage/notification.md
@@ -74,17 +74,15 @@ Here is an example:
 
 ```yaml
 notifications:
- -
-  type: http
-  url: https://mystuff.com/api
-  verify_tls: false
-  headers:
-    Authorization: "Bearer 1234"
- -
-  type: plugin
-  module: chaosslack.notification
-  token: xop-1235
-  channel: general
+  - type: http
+    url: https://mystuff.com/api
+    verify_tls: false
+    headers:
+      Authorization: "Bearer 1234"
+  - type: plugin
+    module: chaosslack.notification
+    token: xop-1235
+    channel: general
 ```
 
 As you can see, channels are items in a list. Each channel is a mapping
@@ -109,13 +107,12 @@ sent. This is done by adding the `events` field to a channel:
 
 ```yaml
 notifications:
- -
-  type: plugin
-  module: chaosslack.notification
-  token: xop-1235
-  channel: general
-  events:
-    - run-failed
+  - type: plugin
+    module: chaosslack.notification
+    token: xop-1235
+    channel: general
+    events:
+      - run-failed
 ```
 
 The Slack channel will only receive events when a run experiment fails. This
@@ -127,7 +124,7 @@ A HTTP notification channel tells the Chaos Toolkit it must send the event
 over HTTP (or HTTPS) to the given endpoint. Here is the description of its
 fields:
 
-- `type`: must `"http"` (required)
+- `type`: `"http"` (required)
 - `url`: the endpoint address (required)
 - `verify_tls`: `true|false` depending if the endpoint certificates are
   self-signed
@@ -153,7 +150,7 @@ channels as they are fully fledged Python functions.
 
 Here are the fields to declare one:
 
-- `type`: must `"plugin"` (required)
+- `type`: `"plugin"` (required)
 - `module`: the dotted path to the Python module containing the function to
   apply (required)
 - `func`: the name of the function to apply (in that module), defaults to
@@ -164,11 +161,10 @@ For instance:
 
 ```yaml
 notifications:
- -
-  type: plugin
-  module: chaosslack.notification
-  token: xop-1235
-  channel: general
+  - type: plugin
+    module: chaosslack.notification
+    token: xop-1235
+    channel: general
 ```
 
 The `token` and `channel` fields will be provided directly to the `notify`
@@ -176,25 +172,24 @@ function of the `chaosslack.notification` module.
 
 ## Send Notifications To Slack
 
-Notifying about Chaos Experiment in a slack channel is so common that we will
+Notifying about Chaos Experiment runs in a Slack channel is so common that we will
 describe this integration here.
 
-First, you must install the [Chaos Toolkit Integration for Slack][sl] as usual:
+First, you must install the [Chaos Toolkit Integration for Slack][sl]:
 
-```console
-(chaostk) $ pip install -U chaostoolkit-slack
+```
+pip install -U chaostoolkit-slack
 ```
 
 Then, you should declare your notification channels as follows in the Chaos
-Toolkit settings file.
+Toolkit settings file:
 
 ```yaml
 notifications:
- -
-  type: plugin
-  module: chaosslack.notification
-  token: xop-1235
-  channel: general
+  - type: plugin
+    module: chaosslack.notification
+    token: xop-1235
+    channel: general
 ```
 
 You may define as many channels as you need, for instance for different kind
@@ -210,7 +205,7 @@ before moving on to a [Slack App](slackapp) as per Slack [guidelines][].
 
 The Chaos Toolkit itself does not provide a Slack App at this moment.
 
-The channel must be a name of an existing channel. The
+The `channel` must be a name of an existing channel. The
 payload message sent to Slack is defined in the [plugin][sl]. If you need to
 amend it, please open an [issue][slissue] there.
 
@@ -220,9 +215,8 @@ amend it, please open an [issue][slissue] there.
 
 The Chaos Toolkit does its best to not break the experiment when an event
 could not be pushed. If you do not see the notification you were expecting,
-you should start investigating in the `chaostoolkit.og` file. Indeed, in that
-case the error is logged at the `DEBUG` level with, hopefully, enough
-information why the event could not be sent.
+you should start investigating in the `chaostoolkit.log` file. If Chaos Toolkit could handle the issue
+gracefully, it will log the error at the `DEBUG` level.
 
 If the error occurs inside the core Chaos Toolkit library, please raise an
 [issue there][chaoslibissues]. Otherwise, raise an issue with the appropriate


### PR DESCRIPTION
This PR tidies up `notification.md` by removing command prefixes and formatting YAML blocks

It also renames the navigation entry from `Notify` to `Notifications`

Signed-off-by: Ciaran Evans <ciaran@reliably.com>
