### PR TITLE
Add the CLI to Reference

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -95,6 +95,14 @@ nav:
       - Concepts: reference/concepts.md
       - Experiment: reference/api/experiment.md
       - Journal: reference/api/journal.md
+    - CLI:
+        - Overview: reference/usage/cli.md
+        - Discover: reference/usage/discover.md
+        - Init: reference/usage/init.md
+        - Run: reference/usage/run.md
+        - Report: reference/usage/report.md
+        - Notifications: reference/usage/notification.md
+        - Schedule: reference/usage/scheduling.md
     - Extensions:
         - Overview: drivers/overview.md
         - Infrastructure/Platform:


### PR DESCRIPTION
This PR adds a section on the CLI in the Reference documentation.

Usually this is where you'd expect such material, but we were only displaying it in `Get Started`

Signed-off-by: Ciaran Evans <ciaran@reliably.com>
