### PR TITLE
Re-enable Google Analytics with new mkdocs format

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -22,14 +22,11 @@ theme:
     - navigation.tabs.sticky
     - navigation.top
     - search.suggest
+  analytics:
+    gtag: G-281427321
 extra_css:
   - 'static/css/extra.css'
 docs_dir: sources
-# wait until new release of material is pushed out
-# see https://www.mkdocs.org/about/release-notes/#backward-incompatible-changes-in-12
-#google_analytics:
-#  - UA-107338053-1
-#  - auto
 repo_name: chaostoolkit
 repo_url: https://github.com/chaostoolkit/chaostoolkit
 markdown_extensions:


### PR DESCRIPTION
As per https://www.mkdocs.org/about/release-notes/#backward-incompatible-changes-in-12 and the guidance in https://github.com/mkdocs/mkdocs/issues/2252, the `mkdocs` format for Google Analytics has changed.

This PR amends the format we had and re-enables Google Analytics for chaostoolkit.org

Signed-off-by: Ciaran Evans <ciaran@reliably.com>
