### PR TITLE
Explicit Directory Directing and GitLinks

### DIFF
--- a/sources/reference/tutorial.md
+++ b/sources/reference/tutorial.md
@@ -28,13 +28,20 @@ git clone https://github.com/chaostoolkit/chaostoolkit-documentation-code
 
 This particular tutorial is under `tutorials/a-simple-walkthrough`.
 
+```console
+cd chaostoolkit-documentation-code/tutorials/a-simple-walkthrough
+```
+
 ### Third-party binaries
 
 The experiment will use the following binaries, make sure you have them in your
 PATH:
 
-* openssl
-* pkill
+* [openssl][opensslgitlink]
+* [pkill][pkillgitlink]
+
+[opensslgitlink]: https://github.com/openssl/openssl
+[pkillgitlink]: https://github.com/fosskers/pkill
 
 ### Install the Application dependencies
 


### PR DESCRIPTION
Added command to explicitly move to the: `chaostoolkit-documentation-code/tutorials/a-simple-walkthrough` directory

Added GitHub links to the third-party binaries: openssl & pkill

Signed-off-by: Charlie Moon <charlie@chaosiq.io>