### PR TITLE
Corrected weblink

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 Get to the [documentation][live] of the Chaos Toolkit.
 
-[live]: http://docs.chaostoolkit.org/
+[live]: https://chaostoolkit.org
 
 ## Contribute to the documentation
 


### PR DESCRIPTION
Just changes the web link from: https://docs.chaostoolkit.org to https://chaostoolkit.org

Signed-off-by: Charlie Moon <charlie@chaosiq.io>

closes: #128 