### PR TITLE
Documentation Specified Wrong Version

### DIFF
--- a/sources/deployment/k8s/operator.md
+++ b/sources/deployment/k8s/operator.md
@@ -85,7 +85,6 @@ metadata:
 data:
   experiment.json: |
     {
-      "version": "1.0.0",
       "title": "Hello world!",
       "description": "Say hello world.",
       "method": [

--- a/sources/drivers/azure.md
+++ b/sources/drivers/azure.md
@@ -163,7 +163,6 @@ Here is a full example:
 
 ```json
 {
-  "version": "1.0.0",
   "title": "...",
   "description": "...",
   "tags": [

--- a/sources/drivers/gandi.md
+++ b/sources/drivers/gandi.md
@@ -36,7 +36,6 @@ experiment file:
 
 ```json
 {
-    "version": "1.0.0",
     "title": "Our domains are not going expiring within a month",
     "description": "We need time to renew.",
     "secrets": {

--- a/sources/drivers/gcp.md
+++ b/sources/drivers/gcp.md
@@ -151,7 +151,6 @@ Here is a full example:
 
 ```json
 {
-    "version": "1.0.0",
     "title": "...",
     "description": "...",
     "configuration": {

--- a/sources/drivers/service-fabric.md
+++ b/sources/drivers/service-fabric.md
@@ -131,7 +131,6 @@ Here is a full example:
 
 ```json
 {
-    "version": "1.0.0",
     "title": "...",
     "description": "...",
     "configuration": {

--- a/sources/reference/api/experiment.md
+++ b/sources/reference/api/experiment.md
@@ -84,12 +84,9 @@ An experiment is a JSON object.
 
 An experiment MUST declare:
 
-* a `version` property
 * a `title` property
 * a `description` property
 * a `method` property
-
-The `version` property MUST be `"1.0.0"`.
 
 The experiment's `title` and `description` are meant for humans and therefore
 should be as descriptive as possible to clarify the experiment's rationale.
@@ -1004,7 +1001,6 @@ Here is an example of the most minimal experiment:
 
 ```json
 {
-    "version": "1.0.0",
     "title": "Moving a file from under our feet is forgivable",
     "description": "Our application should re-create a file that was removed",
     "contributions": {
@@ -1057,7 +1053,6 @@ the specification herein):
 
 ```yaml
 ---
-version: 1.0.0
 title: Moving a file from under our feet is forgivable
 description: Our application should re-create a file that was removed
 contributions:
@@ -1096,7 +1091,6 @@ to perform actions, probing and steady-state hypothesis validation.
 
 ```json
 {
-    "version": "1.0.0",
     "title": "Are our users impacted by the loss of a function?",
     "description": "While users query the Astre function, they should not be impacted if one instance goes down.",
     "contributions": {
@@ -1231,7 +1225,6 @@ The equivalent YAML serialization:
 
 ```yaml
 ---
-version: 1.0.0
 title: Are our users impacted by the loss of a function?
 description: While users query the Astre function, they should not be impacted if
   one instance goes down.

--- a/sources/reference/api/experiment.md
+++ b/sources/reference/api/experiment.md
@@ -89,7 +89,7 @@ An experiment MUST declare:
 * a `description` property
 * a `method` property
 
-The `version` property MUST be `"0.1.0"`.
+The `version` property MUST be `"1.0.0"`.
 
 The experiment's `title` and `description` are meant for humans and therefore
 should be as descriptive as possible to clarify the experiment's rationale.

--- a/sources/reference/concepts.md
+++ b/sources/reference/concepts.md
@@ -19,7 +19,6 @@ project:
 
 ```json
 {
-    "version": "1.0.0",
     "title": "System is resilient to provider's failures",
     "description": "Can our consumer survive gracefully a provider's failure?",
     "tags": [

--- a/sources/reference/tutorials/blockchain.md
+++ b/sources/reference/tutorials/blockchain.md
@@ -71,8 +71,6 @@ We'll use this as an introduction to the CTK experiment as well. An experiment
 is a single json file which tests a functionality of your program. It has
 several components that _must_ be declared:
 
-- `version`
-  - Currently, this should always be set to `1.0.0`
 - `title`
   - This forces you to be organised with your experiments. The title should be
     clear for anyone reading it to understand what is being performed in the
@@ -96,7 +94,6 @@ This is the beginning of my experiment:
 
 ```json
 {
-    "version": "1.0.0",
     "title": "Can we make a new transaction?",
     "description": "The system should respond to a transaction request.",
     "tags": ["tx"],

--- a/sources/reference/tutorials/blockchain.md
+++ b/sources/reference/tutorials/blockchain.md
@@ -72,7 +72,7 @@ is a single json file which tests a functionality of your program. It has
 several components that _must_ be declared:
 
 - `version`
-  - Currently, this should always be set to `0.1.0`
+  - Currently, this should always be set to `1.0.0`
 - `title`
   - This forces you to be organised with your experiments. The title should be
     clear for anyone reading it to understand what is being performed in the

--- a/sources/reference/tutorials/tolerance.md
+++ b/sources/reference/tutorials/tolerance.md
@@ -20,7 +20,6 @@ Let's take the simple experimant below:
 
 ```json
 {
-  "version": "1.0.0",
   "title": "Our default language is English",
   "description": "We find the expected English language in the file",
   "steady-state-hypothesis": {


### PR DESCRIPTION
Documentation referenced in two places that the `version` tag for .json experiments should be `0.1.0` instead of `1.0.0`
(https://chaostoolkit.org/reference/tutorials/blockchain/#transaction-experiment 
and https://chaostoolkit.org/reference/api/experiment/#experiment)

It turns out that this version control is not required at all and therefore can be removed completely from all instances and therefore there isn't a need to specify it on the Experiment and Blockchain pages

Signed-off-by: Charlie Moon <charlie@chaosiq.io>

closes: #134 
closes: #101 