### PR TITLE
Add AWS CLI version of EC2 instructions

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -50,6 +50,7 @@ markdown_extensions:
   - pymdownx.mark
   - pymdownx.smartsymbols
   - pymdownx.superfences
+  - pymdownx.tabbed
   - pymdownx.tasklist:
       custom_checkbox: True
   - pymdownx.tilde


### PR DESCRIPTION
This PR adds alternate instructions for setting up CTK on EC2 using AWS CLI

* Enables tabs to switch between the console and the CLI

Signed-off-by: Ciaran Evans <ciaran@reliably.com>
