### PR TITLE
Remove hint about experiment spec

### DIFF
--- a/sources/reference/api/experiment.md
+++ b/sources/reference/api/experiment.md
@@ -1,11 +1,5 @@
 # An Open API for Chaos Engineering Experiments
 
-!!! info
-    The current specification has not reached its 1.0.0 stable version yet. Make
-    sure to [join the discussion][join] to provide any feedback you might have.
-
-[join]: https://join.chaostoolkit.org/
-
 [exp]: #experiment
 [hypo]: #steady-state-hypothesis
 [meth]: #method


### PR DESCRIPTION
As we no longer have `version` in experiments, we're removing the hint talking about whether it's stable or not.

Signed-off-by: Ciaran Evans <ciaran@reliably.com>
