### PR TITLE
Update the submodule from remote, not local

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -57,6 +57,6 @@ jobs:
         git clone https://$GH_USER_NAME:$GH_USER_PWD@github.com/chaostoolkit/chaostoolkit-documentation.git .
         git checkout gh-pages
         cd -
-        git submodule update --init
+        git submodule update --init --remote
         mkdocs build --strict -d /tmp/site
         cd ..

--- a/.github/workflows/build_and_deploy.yaml
+++ b/.github/workflows/build_and_deploy.yaml
@@ -57,7 +57,7 @@ jobs:
         git clone https://$GH_USER_NAME:$GH_USER_PWD@github.com/chaostoolkit/chaostoolkit-documentation.git .
         git checkout gh-pages
         cd -
-        git submodule update --init
+        git submodule update --init --remote
         mkdocs build --strict -d /tmp/site
         cd ..
     - name: Deploy 🚀


### PR DESCRIPTION
I believe what is happening is we're running `submodule update` but this is only updating locally (as if the submodules were on the same machine).

This isn't the case, as our submodule is in a repo on Github, I've added the `--remote` flag to see if this is the fix.

Signed-off-by: Ciaran Evans <ciaran@reliably.com>
