### PR TITLE
Update reference documentation by removing invalid katacode tutorial link

### DIFF
--- a/sources/reference/usage/discover.md
+++ b/sources/reference/usage/discover.md
@@ -23,10 +23,9 @@ Options:
   --help                 Show this message and exit.
 ```
 
-A tutorial on how to use the `chaos discover` command is available as part of the 
-[Chaos Toolkit's Getting Started tutorials.](https://www.katacoda.com/chaostoolkit/courses/01-chaostoolkit-getting-started)
 
-### Discovering capabilities and experiments 
+
+### Discovering capabilities and experiments 
 
 To execute `discover` all you need to do is specify the Chaos Toolkit integration
 extension that you'd like to use, for example to use Kubernetes:

--- a/sources/reference/usage/init.md
+++ b/sources/reference/usage/init.md
@@ -23,8 +23,7 @@ Options:
   --help                  Show this message and exit.
 ```
 
-A tutorial on how to use the `chaos init` command is available as part of the 
-[Chaos Toolkit's Getting Started tutorials.](https://www.katacoda.com/chaostoolkit/courses/01-chaostoolkit-getting-started)
+
 
 ### Initialise a new experiment 
 

--- a/sources/reference/usage/report.md
+++ b/sources/reference/usage/report.md
@@ -25,8 +25,6 @@ Options:
   --help                Show this message and exit.
 ```
 
-A tutorial on how to use the `chaos report` command is available as part of the 
-[Chaos Toolkit's Getting Started tutorials.](https://www.katacoda.com/chaostoolkit/courses/01-chaostoolkit-getting-started)
 
 ### Generating a report
 

--- a/sources/reference/usage/run.md
+++ b/sources/reference/usage/run.md
@@ -53,10 +53,8 @@ Options:
   --help                          Show this message and exit.
 ```
 
-A tutorial on how to use the `chaos run` command is available as part of the 
-[Chaos Toolkit's Getting Started tutorials.](https://www.katacoda.com/chaostoolkit/courses/01-chaostoolkit-getting-started)
 
-### Executing an Experiment Plan
+### Executing an Experiment Plan
 
 To execute an experiment plan you simply pass it to the `chaos run` command:
 


### PR DESCRIPTION
To address the issue https://github.com/chaostoolkit/chaostoolkit/issues/304
- discover, init, run, report usage reference documents updated